### PR TITLE
mutate rules should not fail the test

### DIFF
--- a/kyverno-test-util.py
+++ b/kyverno-test-util.py
@@ -55,6 +55,9 @@ def getExpectedResult(rule, resource):
         if 'kinds' in str(rule['exclude']) and resource['metadata']['name'] in rule['exclude']['any'][0]['resources']['names']:
             shouldExclude = 1
 
+    if 'mutate' in rule.keys():
+        shouldExclude = 1
+
     match shouldExclude:
         case 0:
             return 'pass'


### PR DESCRIPTION
At the moment, having a mutating rule fails the complete test. With this PR, the mutate rules will be excluded in the tests.
In a further PR this could get enhanced and the mutation rule might get applied.